### PR TITLE
Adding transition for valign bottom

### DIFF
--- a/paper-menu-button-transition.html
+++ b/paper-menu-button-transition.html
@@ -118,3 +118,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <paper-menu-button-transition id="paper-menu-button-transition-top-right" transformOrigin="100% 0%"></paper-menu-button-transition>
 <paper-menu-button-transition id="paper-menu-button-transition-top-right-slow" transformOrigin="100% 0%" duration="10000"></paper-menu-button-transition>
 <paper-menu-button-transition id="paper-menu-button-transition-top-auto" transformOrigin="0% 0%"></paper-menu-button-transition>
+
+<paper-menu-button-transition id="paper-menu-button-transition-bottom-left" transformOrigin="0% 100%"></paper-menu-button-transition>
+<paper-menu-button-transition id="paper-menu-button-transition-bottom-right" transformOrigin="100% 100%"></paper-menu-button-transition>

--- a/paper-menu-button.css
+++ b/paper-menu-button.css
@@ -71,6 +71,11 @@ core-icon::shadow svg {
 	right: 0;
 }
 
+:host([valign="bottom"]) .paper-menu-button-overlay-ink {
+  top: auto;
+  bottom: 0;
+}
+
 .paper-menu-button-overlay-bg {
 	position: absolute;
 	top: 0;

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -84,7 +84,7 @@ paper-menu-button:shadow .paper-menu-button-overlay-ink {
 
     <core-icon src="{{src}}" icon="{{icon}}"></core-icon>
 
-    <core-dropdown id="dropdown" relatedTarget="{{}}" opened="{{opened}}" halign="{{halign}}" valign="{{valign}}" transition="paper-menu-button-transition-top-{{halign}}{{slow ? '-slow' : ''}}" on-core-transitionend="{{transitionEndAction}}">
+    <core-dropdown id="dropdown" relatedTarget="{{}}" opened="{{opened}}" halign="{{halign}}" valign="{{valign}}" transition="paper-menu-button-transition-{{valign}}-{{halign}}{{slow ? '-slow' : ''}}" on-core-transitionend="{{transitionEndAction}}">
 
       <paper-shadow id="shadow" z="0" target="{{$.dropdown}}"></paper-shadow>
 


### PR DESCRIPTION
This add the transitions for valign bottom and adjusts the tap ink in the css.
To fine tune the bottom animation further, you would need to reverse the order that the menu items appear by checking the valign property prior to assigning delay offsets. Fixes #37 
