### PR TITLE
Scroll by clicking on scrollbar. Fixes #44

### DIFF
--- a/paper-menu-button.css
+++ b/paper-menu-button.css
@@ -57,20 +57,20 @@ core-icon::shadow svg {
 }
 
 .paper-menu-button-overlay-ink {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 40px;
-	height: 40px;
-	border-radius: 20px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: 20px;
   opacity: 0;
   transform: scale(0);
   -webkit-transform: scale(0);
 }
 
 :host([halign="right"]) .paper-menu-button-overlay-ink {
-	left: auto;
-	right: 0;
+  left: auto;
+  right: 0;
 }
 
 :host([valign="bottom"]) .paper-menu-button-overlay-ink {
@@ -79,13 +79,14 @@ core-icon::shadow svg {
 }
 
 .paper-menu-button-overlay-bg {
-	position: absolute;
-	top: 0;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	border-radius: 3px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  border-radius: 3px;
   opacity: 0;
+  z-index: -1;
 }
 
 :host([noTransition]) .paper-menu-button-overlay-bg {

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -76,13 +76,13 @@ paper-menu-button:shadow .paper-menu-button-overlay-ink {
   })();
 </script>
 
-<polymer-element name="paper-menu-button" extends="paper-focusable" attributes="src icon opened halign valign slow" on-tap="{{tapAction}}">
+<polymer-element name="paper-menu-button" extends="paper-focusable" attributes="src icon opened halign valign slow">
   <template>
 
     <link rel="stylesheet" href="paper-menu-button.css">
     <core-style ref="paper-menu-button"></core-style>
 
-    <core-icon src="{{src}}" icon="{{icon}}"></core-icon>
+    <core-icon src="{{src}}" icon="{{icon}}" on-tap="{{tapAction}}"></core-icon>
 
     <core-dropdown id="dropdown" relatedTarget="{{}}" opened="{{opened}}" halign="{{halign}}" valign="{{valign}}" transition="{{noTransition ? '' : transition}}" on-core-transitionend="{{transitionEndAction}}">
 
@@ -92,7 +92,7 @@ paper-menu-button:shadow .paper-menu-button-overlay-ink {
       <div id="overlayBg" class="paper-menu-button-overlay-bg"></div>
 
       <div class="paper-menu-button-menu-container">
-        <core-menu id="menu" selected="{{selected}}" selectedItem="{{selectedItem}}" selectedClass="{{selectedClass}}" valueattr="{{valueattr}}" selectedProperty="{{selectedProperty}}" selectedAttribute="{{selectedAttribute}}" on-core-select="{{selectAction}}">
+        <core-menu id="menu" selected="{{selected}}" selectedItem="{{selectedItem}}" selectedClass="{{selectedClass}}" valueattr="{{valueattr}}" selectedProperty="{{selectedProperty}}" selectedAttribute="{{selectedAttribute}}" on-core-select="{{selectAction}}" on-core-activate="{{activateAction}}">
           <content></content>
         </core-menu>
       </div>
@@ -182,6 +182,10 @@ paper-menu-button:shadow .paper-menu-button-overlay-ink {
 
       transitionEndAction: function() {
         this.$.shadow.z = 1;
+      },
+
+      activateAction: function() {
+        this.opened = false;
       },
 
       /**


### PR DESCRIPTION
To fix this, I had to move the `on-tap` handler to the `<core-icon>`. Otherwise, `<paper-menu-button>` would be the event target and I wouldn't be able to detect if `<core-icon>` was clicked or something else.

Another part of the fix is to set a negative z-index for `.paper-menu-button-overlay-bg`. Currently, this background is covering the scrollbar and making it impossible to grab (you can verify this by changing Mac System Preferences to always show scroll bars).

Reviewers @sorvell and @frankiefu 
